### PR TITLE
Added permfind as an should_be_array command

### DIFF
--- a/lib/teamspeak-ruby/client.rb
+++ b/lib/teamspeak-ruby/client.rb
@@ -106,7 +106,7 @@ module Teamspeak
         channelfind channelgrouplist channelgrouppermlist channelpermlist
         clientlist clientfind clientdblist clientdbfind channelclientpermlist
         permissionlist permoverview privilegekeylist messagelist complainlist
-        banlist ftlist custominfo
+        banlist ftlist custominfo permfind
       )
 
       parsed_response = parse_response(response)


### PR DESCRIPTION
The command permfind should return an array, but it's not in the list.