### PR TITLE
Add channelgroupclientlist to should_be_array

### DIFF
--- a/lib/teamspeak-ruby/client.rb
+++ b/lib/teamspeak-ruby/client.rb
@@ -105,10 +105,10 @@ module Teamspeak
       should_be_array = %w(
         bindinglist serverlist servergrouplist servergroupclientlist
         servergroupsbyclientid servergroupclientlist logview channellist
-        channelfind channelgrouplist channelgrouppermlist channelpermlist
-        clientlist clientfind clientdblist clientdbfind channelclientpermlist
-        permissionlist permoverview privilegekeylist messagelist complainlist
-        banlist ftlist custominfo permfind
+        channelfind channelgrouplist channelgroupclientlist channelgrouppermlist
+        channelpermlist clientlist clientfind clientdblist clientdbfind
+        channelclientpermlist permissionlist permoverview privilegekeylist
+        messagelist complainlist banlist ftlist custominfo permfind
       )
 
       parsed_response = parse_response(response)


### PR DESCRIPTION
This PR adds `channelgroupclientlist` to the `should_be_array` list, which prevents its return value from being truncated to a single item.