### PR TITLE
Do not mutate strings as it will break frozen string literals

### DIFF
--- a/lib/teamspeak-ruby/client.rb
+++ b/lib/teamspeak-ruby/client.rb
@@ -142,7 +142,7 @@ module Teamspeak
       return param.to_i if param.to_i.to_s == param
 
       SPECIAL_CHARS.each do |pair|
-        param.gsub!(pair[0], pair[1])
+        param = param.gsub(pair[0], pair[1])
       end
 
       param
@@ -150,7 +150,7 @@ module Teamspeak
 
     def encode_param(param)
       SPECIAL_CHARS.each do |pair|
-        param.gsub!(pair[1], pair[0])
+        param = param.gsub(pair[1], pair[0])
       end
 
       param

--- a/lib/teamspeak-ruby/version.rb
+++ b/lib/teamspeak-ruby/version.rb
@@ -1,3 +1,3 @@
 module Teamspeak
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.1.1'.freeze
 end


### PR DESCRIPTION
Ensure compatibility with ruby 2.3 new `# frozen_string_literal: true` pragma.